### PR TITLE
Support for frameworks

### DIFF
--- a/NSDate+RelativeTime.m
+++ b/NSDate+RelativeTime.m
@@ -21,7 +21,7 @@ const int YEAR = DAY*365;
 -(NSString *)relativeTime
 {
     NSDate *currentDate = [NSDate date];
-    int deltaSeconds = fabs(lroundf([self timeIntervalSinceDate:currentDate]));
+    long deltaSeconds = labs(lroundf([self timeIntervalSinceDate:currentDate]));
     BOOL dateInFuture = ([self timeIntervalSinceDate:currentDate] > 0);
     
     if(deltaSeconds < 2*SECOND) {
@@ -61,7 +61,7 @@ const int YEAR = DAY*365;
     }
 }
 
--(NSString *)formattedStringForCurrentDate:(NSDate *)currentDate count:(int)count past:(NSString *)past future:(NSString *)future
+-(NSString *)formattedStringForCurrentDate:(NSDate *)currentDate count:(long)count past:(NSString *)past future:(NSString *)future
 {
     if ([self timeIntervalSinceDate:currentDate] > 0) {
         return [NSString stringWithFormat: [self NSDateRelativeTimeLocalizedStrings: future], count];

--- a/NSDate+RelativeTime.m
+++ b/NSDate+RelativeTime.m
@@ -8,6 +8,12 @@
 
 #import "NSDate+RelativeTime.h"
 
+@interface NSDate_RelativeTime : NSObject
+
++(NSString *)localizedString:(NSString *)key;
+
+@end
+
 @implementation NSDate (RelativeTime)
 
 const int SECOND = 1;
@@ -25,36 +31,36 @@ const int YEAR = DAY*365;
     BOOL dateInFuture = ([self timeIntervalSinceDate:currentDate] > 0);
     
     if(deltaSeconds < 2*SECOND) {
-        return [self NSDateRelativeTimeLocalizedStrings: @"Now"];
+        return [NSDate_RelativeTime localizedString: @"Now"];
     } else if(deltaSeconds < MINUTE) {
         return [self formattedStringForCurrentDate:currentDate count:deltaSeconds past:@"%d seconds ago" future:@"%d seconds from now"];
     } else if(deltaSeconds < 1.5*MINUTE) {
-        return !dateInFuture ? [self NSDateRelativeTimeLocalizedStrings: @"A minute ago"] : [self NSDateRelativeTimeLocalizedStrings: @"A minute from now"];
+        return !dateInFuture ? [NSDate_RelativeTime localizedString: @"A minute ago"] : [NSDate_RelativeTime localizedString: @"A minute from now"];
     } else if(deltaSeconds < HOUR) {
         int minutes = (int)lroundf((float)deltaSeconds/(float)MINUTE);
         return [self formattedStringForCurrentDate:currentDate count:minutes past:@"%d minutes ago" future:@"%d minutes from now"];
     } else if(deltaSeconds < 1.5*HOUR) {
-        return !dateInFuture ? [self NSDateRelativeTimeLocalizedStrings: @"An hour ago"] : [self NSDateRelativeTimeLocalizedStrings: @"An hour from now"];
+        return !dateInFuture ? [NSDate_RelativeTime localizedString: @"An hour ago"] : [NSDate_RelativeTime localizedString: @"An hour from now"];
     } else if(deltaSeconds < DAY) {
         int hours = (int)lroundf((float)deltaSeconds/(float)HOUR);
         return [self formattedStringForCurrentDate:currentDate count:hours past:@"%d hours ago" future:@"%d hours from now"];
     } else if(deltaSeconds < 1.5*DAY) {
-        return !dateInFuture ? [self NSDateRelativeTimeLocalizedStrings: @"A day ago"] : [self NSDateRelativeTimeLocalizedStrings: @"A day from now"];
+        return !dateInFuture ? [NSDate_RelativeTime localizedString: @"A day ago"] : [NSDate_RelativeTime localizedString: @"A day from now"];
     } else if(deltaSeconds < WEEK) {
         int days = (int)lroundf((float)deltaSeconds/(float)DAY);
         return [self formattedStringForCurrentDate:currentDate count:days past:@"%d days ago" future:@"%d days from now"];
     } else if(deltaSeconds < 1.5*WEEK) {
-        return !dateInFuture ? [self NSDateRelativeTimeLocalizedStrings: @"A week ago"] : [self NSDateRelativeTimeLocalizedStrings: @"A week from now"];
+        return !dateInFuture ? [NSDate_RelativeTime localizedString: @"A week ago"] : [NSDate_RelativeTime localizedString: @"A week from now"];
     } else if(deltaSeconds < MONTH) {
         int weeks = (int)lroundf((float)deltaSeconds/(float)WEEK);
         return [self formattedStringForCurrentDate:currentDate count:weeks past:@"%d weeks ago" future:@"%d weeks from now"];
     } else if(deltaSeconds < 1.5*MONTH) {
-        return !dateInFuture ? [self NSDateRelativeTimeLocalizedStrings: @"A month ago"] : [self NSDateRelativeTimeLocalizedStrings: @"A month from now"];
+        return !dateInFuture ? [NSDate_RelativeTime localizedString: @"A month ago"] : [NSDate_RelativeTime localizedString: @"A month from now"];
     } else if(deltaSeconds < YEAR) {
         int months = (int)lroundf((float)deltaSeconds/(float)MONTH);
         return [self formattedStringForCurrentDate:currentDate count:months past:@"%d months ago" future:@"%d months from now"];
     } else if(deltaSeconds < 1.5*YEAR) {
-        return !dateInFuture ? [self NSDateRelativeTimeLocalizedStrings: @"A year ago"] : [self NSDateRelativeTimeLocalizedStrings: @"A year from now"];
+        return !dateInFuture ? [NSDate_RelativeTime localizedString: @"A year ago"] : [NSDate_RelativeTime localizedString: @"A year from now"];
     } else {
         int years = (int)lroundf((float)deltaSeconds/(float)YEAR);
         return [self formattedStringForCurrentDate:currentDate count:years past:@"%d years ago" future:@"%d years from now"];
@@ -64,15 +70,24 @@ const int YEAR = DAY*365;
 -(NSString *)formattedStringForCurrentDate:(NSDate *)currentDate count:(long)count past:(NSString *)past future:(NSString *)future
 {
     if ([self timeIntervalSinceDate:currentDate] > 0) {
-        return [NSString stringWithFormat: [self NSDateRelativeTimeLocalizedStrings: future], count];
+        return [NSString stringWithFormat: [NSDate_RelativeTime localizedString: future], count];
     } else {
-        return [NSString stringWithFormat: [self NSDateRelativeTimeLocalizedStrings: past], count];
+        return [NSString stringWithFormat: [NSDate_RelativeTime localizedString: past], count];
     }
 }
 
--(NSString *)NSDateRelativeTimeLocalizedStrings:(NSString *)key
+@end
+
+@implementation NSDate_RelativeTime
+
++(NSString *)localizedString:(NSString *)key
 {
-    return NSLocalizedStringFromTableInBundle(key, @"NSDate+RelativeTime", [NSBundle bundleWithPath:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"NSDate+RelativeTime.bundle"]], nil);
+    static NSBundle *bundle;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        bundle = [NSBundle bundleWithPath:[[[NSBundle bundleForClass:self] resourcePath] stringByAppendingPathComponent:@"NSDate+RelativeTime.bundle"]];
+    });
+    return NSLocalizedStringFromTableInBundle(key, @"NSDate+RelativeTime", bundle, nil);
 }
 
 @end


### PR DESCRIPTION
This creates a class to handle strings, using [NSBundle bundleForClass:] to load the strings table, so it works when integrating the pod as a framework.
